### PR TITLE
Update for HA 2023.8 MQTT changes

### DIFF
--- a/mqtt.js
+++ b/mqtt.js
@@ -35,7 +35,6 @@ const getSettingsTopic = () => `plejd/settings`;
 
 const getDiscoveryPayload = device => ({
   schema: 'json',
-  name: device.name,
   unique_id: `light.plejd.${device.name.toLowerCase().replace(/ /g, '')}`,
   state_topic: getStateTopic(device),
   command_topic: getCommandTopic(device),
@@ -52,7 +51,7 @@ const getDiscoveryPayload = device => ({
 });
 
 const getSwitchPayload = device => ({
-  name: device.name,
+  unique_id: `light.plejd.${device.name.toLowerCase().replace(/ /g, '')}`,
   state_topic: getStateTopic(device),
   command_topic: getCommandTopic(device),
   optimistic: false,


### PR DESCRIPTION
In 2023.8 MQTT have been changed to only have the name of the device, not the entity.

Source: https://community.home-assistant.io/t/psa-mqtt-name-changes-in-2023-8/598099

Removed the name for the device and added a `unique_id` for switches (I think I got some complaints/warning in the log about this).